### PR TITLE
Add toUnicodeString() as an alias for toString(true)

### DIFF
--- a/src/Card.php
+++ b/src/Card.php
@@ -73,6 +73,11 @@ class Card implements \JsonSerializable
         return $this->face->symbol().($useSuitSymbols ? $this->suit->symbol() : $this->suit->text());
     }
 
+    public function toUnicodeString(): string
+    {
+        return $this->toString(true);
+    }
+
     public static function random(): self
     {
         return new self(


### PR DESCRIPTION
Add ```toUnicodeString()``` as an alias for ```toString(true)``` to make the expected return value more intuitive.

(Very nice package! Thanks for sharing it!)